### PR TITLE
Add notifier conditions

### DIFF
--- a/Tests/Public/When.tests.ps1
+++ b/Tests/Public/When.tests.ps1
@@ -70,6 +70,6 @@ InModuleScope Watchmen {
                 When 'Always'
                 $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Always'
             }
-        }        
+        }
     }
 }

--- a/Tests/Public/When.tests.ps1
+++ b/Tests/Public/When.tests.ps1
@@ -1,0 +1,75 @@
+
+InModuleScope Watchmen {
+
+    describe 'When' {
+
+        context 'In WatchmenOptions' {
+
+            Mock -CommandName Assert-InWatchmen -MockWith {}
+
+            BeforeEach {
+                $global:watchmen = @{
+                    InConfig = $true
+                    InTest = $false
+                    Options = @{
+                        NotifierConditions = @{
+                            WatchmenOptions = 'OnFailure'
+                            WatchmenTest = 'OnFailure'
+                        }
+                    }
+                }
+            }
+
+            it 'Sets the default notifier condition to [OnFailure]' {
+                When 'OnFailure'
+                $global:Watchmen.Options.NotifierConditions.WatchmenOptions | should be 'Onfailure'
+                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Onfailure'
+            }
+
+            it 'Sets the default notifier condition to [OnSuccess]' {
+                When 'OnSuccess'
+                $global:Watchmen.Options.NotifierConditions.WatchmenOptions | should be 'OnSuccess'
+                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'OnSuccess'
+            }
+
+            it 'Sets the default notifier condition to [Always]' {
+                When 'Always'
+                $global:Watchmen.Options.NotifierConditions.WatchmenOptions | should be 'Always'
+                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Always'
+            }
+        }
+
+        context 'In WatchmenTest' {
+
+            Mock -CommandName Assert-InWatchmen -MockWith {}
+
+            BeforeEach {
+                $global:watchmen = @{
+                    InConfig = $false
+                    InTest = $true
+                    Options = @{
+                        NotifierConditions = @{
+                            WatchmenOptions = 'OnFailure'
+                            WatchmenTest = 'OnFailure'
+                        }
+                    }
+                }
+            }
+
+            it 'Sets the default notifier condition to [OnFailure]' {
+                When 'OnFailure'
+                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Onfailure'
+            }
+
+            it 'Sets the default notifier condition to [OnSuccess]' {
+                When 'OnSuccess'
+                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'OnSuccess'
+            }
+
+            it 'Sets the default notifier condition to [Always]' {
+                When 'Always'
+                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Always'
+            }
+        }        
+    }
+}

--- a/Watchmen/Private/Initialize-Watchmen.ps1
+++ b/Watchmen/Private/Initialize-Watchmen.ps1
@@ -4,6 +4,9 @@ function Initialize-Watchmen {
 
     Write-Verbose 'Initializing Watchmen config'
     Remove-Variable -Name Watchmen -Scope Global -ErrorAction Ignore
+
+    $defaultNotifierCondition = 'OnFailure'
+
     $global:Watchmen = [pscustomobject]@{
         PSTypeName = 'Watchmen.State'
         CurrentTestSetId = 0
@@ -13,8 +16,11 @@ function Initialize-Watchmen {
         CurrentWatchmenFileRoot = $null
         Options = [pscustomobject]@{
             PSTypeName = 'Watchmen.Config'
-            #Notifiers = @()
-            Notifiers = @{
+            NotifierConditions = @{
+                WatchmenOptions = $defaultNotifierCondition
+                WatchmenTest = $defaultNotifierCondition
+            }
+            Notifiers = [ordered]@{
                 Email = @()
                 EventLog = @()
                 LogFile = @()
@@ -26,7 +32,7 @@ function Initialize-Watchmen {
                 Endpoint = $null
                 Credential = $null
             }
-            NotifierOptions = @{}
+            #NotifierOptions = @{}
         }
         ThisTest = $null
         TestSets = @(
@@ -39,4 +45,6 @@ function Initialize-Watchmen {
              }
         )
     }
+
+    Write-Verbose "NotifierConditions initialized:`n$($global:watchmen.options.notifierconditions | ft | out-string)"
 }

--- a/Watchmen/Private/Invoke-WatchmeNotifier.ps1
+++ b/Watchmen/Private/Invoke-WatchmeNotifier.ps1
@@ -26,28 +26,36 @@ function Invoke-WatchmenNotifier {
                 if ($notifierType.Count -gt 0) {
                     foreach ($notifier in $notifierType) {
                         if ($notifier.Enabled) {
-                            Write-Verbose -Message "  Calling notifier [$($notifier.type)]"
-                            switch ($notifier.type) {
-                                'Email' {
-                                    $results += $notifier | Invoke-NotifierEmail -Results $testResult
-                                }
-                                'EventLog' {
-                                    $results += $notifier | Invoke-NotifierEventLog -Results $testResult
-                                }
-                                'LogFile' {
-                                    $results += $notifier | Invoke-NotifierLogFile -Results $testResult
-                                }
-                                'PowerShell' {
-                                    $results += $notifier | Invoke-NotifierPowerShell -Results $testResult
-                                }
-                                'Slack' {
-                                    $results += $notifier | Invoke-NotifierSlack -Results $testResult
-                                }
-                                'Syslog' {
-                                    $results += $notifier | Invoke-NotifierSyslog -Results $testResult
-                                }
-                                default {
-                                    Write-Error -Message "Unknown notifier [$($notifier.type)]"
+                            
+                            # Only execute the notifier if one of the following conditions are met
+                            if ( ($notifier.NotifierCondition -eq 'Always') -or
+                                 ($notifier.NotifierCondition -eq 'OnSuccess' -and $testResult.Result -eq 'Passed') -or
+                                 ($notifier.NotifierCondition -eq 'OnFailure' -and $testResult.Result -eq 'Failed')) {
+
+                                Write-Verbose -Message "  Calling notifier [$($notifier.type)]"
+
+                                switch ($notifier.type) {
+                                    'Email' {
+                                        $results += $notifier | Invoke-NotifierEmail -Results $testResult
+                                    }
+                                    'EventLog' {
+                                        $results += $notifier | Invoke-NotifierEventLog -Results $testResult
+                                    }
+                                    'LogFile' {
+                                        $results += $notifier | Invoke-NotifierLogFile -Results $testResult
+                                    }
+                                    'PowerShell' {
+                                        $results += $notifier | Invoke-NotifierPowerShell -Results $testResult
+                                    }
+                                    'Slack' {
+                                        $results += $notifier | Invoke-NotifierSlack -Results $testResult
+                                    }
+                                    'Syslog' {
+                                        $results += $notifier | Invoke-NotifierSyslog -Results $testResult
+                                    }
+                                    default {
+                                        Write-Error -Message "Unknown notifier [$($notifier.type)]"
+                                    }
                                 }
                             }
                         } else {

--- a/Watchmen/Public/Email.ps1
+++ b/Watchmen/Public/Email.ps1
@@ -14,8 +14,6 @@ function Email {
     }
 
     process {
-        $global:Watchmen.ThisTest.Notifiers.EmailCondition = $When
-
         $e = [pscustomobject]@{
             PSTypeName = 'Watchmen.Notifier.Email'
             Type = 'Email'
@@ -29,6 +27,7 @@ function Email {
             UseSSL = $Options.UseSSL
             To = $Options.To
             Enabled = $true
+            NotifierCondition = $When
         }
 
         return $e

--- a/Watchmen/Public/Email.ps1
+++ b/Watchmen/Public/Email.ps1
@@ -2,7 +2,10 @@ function Email {
     [cmdletbinding()]
     param(
         [parameter(Mandatory, Position = 0)]
-        [hashtable]$Options
+        [hashtable]$Options,
+
+        [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
+        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {
@@ -11,6 +14,8 @@ function Email {
     }
 
     process {
+        $global:Watchmen.ThisTest.Notifiers.EmailCondition = $When
+
         $e = [pscustomobject]@{
             PSTypeName = 'Watchmen.Notifier.Email'
             Type = 'Email'

--- a/Watchmen/Public/EventLog.ps1
+++ b/Watchmen/Public/EventLog.ps1
@@ -2,7 +2,10 @@ function EventLog {
     [cmdletbinding()]
     param(
         [parameter(Mandatory, Position = 0)]
-        [hashtable[]]$Options
+        [hashtable[]]$Options,
+
+        [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
+        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {
@@ -18,6 +21,7 @@ function EventLog {
             EventType = $Options.EventType
             EventId = $Options.EventId
             Enabled = $true
+            NotifierCondition = $When
         }
 
         return $e

--- a/Watchmen/Public/Invoke-WatchmenTest.ps1
+++ b/Watchmen/Public/Invoke-WatchmenTest.ps1
@@ -26,6 +26,8 @@ function Invoke-WatchmenTest {
         $tests = @()
 
         $finalResults = @()
+
+        Write-Verbose -Message '[DisableNotifiers] set. No notifiers will be executed.'
     }
 
     process {
@@ -49,7 +51,7 @@ function Invoke-WatchmenTest {
                 # Optionally filter the tests by name
                 if ($test.Test) {
                     Write-Debug "Filtering tests for [$($Test.Test)]"
-                    $filtered = $ovfTestInfo | where Name -like $test.Test
+                    $filtered = $ovfTestInfo | Where-Object Name -like $test.Test
                 }
 
                 # Execute the OVF test
@@ -64,18 +66,11 @@ function Invoke-WatchmenTest {
                     }
                 }
 
-                #if (@($testResults | Where Result -eq 'Failed').Count -gt 0) {
-                #    foreach ($failedTest in $testResults | Where Result -eq 'Failed') {
-                #        Write-Warning -Message "Failed: $($failedTest.Name)" 
-                #    }
-                #}
-
-                # Call notifiers on any failures unless told not to
-                if (-not $PSBoundParameters.ContainsKey('DisableNotifiers')) {
-                    $failedTests = @($testResults | ? {'Failed' -in $_.Result})
-                    if ($failedTests.Count -gt 0) {
-                        Invoke-WatchmenNotifier -TestResults $failedTests -WatchmenTest $test
-                    }
+                # Call notifiers on unless told not to
+                if (-not $PSBoundParameters.ContainsKey('DisableNotifiers')) {                    
+                    Invoke-WatchmenNotifier -TestResults $testResults -WatchmenTest $test                
+                } else {
+                    Write-Verbose ''
                 }
 
                 # TODO
@@ -89,8 +84,8 @@ function Invoke-WatchmenTest {
     }
 
     end {
-        $pass = @($finalResults | Where Result -eq 'Passed').Count
-        $fail = @($finalResults | Where Result -eq 'Failed').Count
+        $pass = @($finalResults | Where-Object Result -eq 'Passed').Count
+        $fail = @($finalResults | Where-Object Result -eq 'Failed').Count
         Write-Verbose -Message "Test results: Passed [$Pass] -- Failed [$fail]"
         Write-Debug -Message "Exiting: $($PSCmdlet.MyInvocation.MyCommand.Name)"
     }

--- a/Watchmen/Public/LogFile.ps1
+++ b/Watchmen/Public/LogFile.ps1
@@ -2,7 +2,10 @@ function LogFile {
     [cmdletbinding()]
     param(
         [parameter(Mandatory, Position = 0)]
-        [string[]]$Path
+        [string[]]$Path,
+
+        [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
+        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {
@@ -17,6 +20,7 @@ function LogFile {
             Name = $Path
             Path = $Path
             Enabled = $true
+            NotifierCondition = $When
         }
 
         return $e

--- a/Watchmen/Public/Notifies.ps1
+++ b/Watchmen/Public/Notifies.ps1
@@ -1,18 +1,35 @@
 function Notifies {
     param(
         [parameter(Mandatory, Position = 0)]
-        [scriptblock]$Script
+        [scriptblock]$Script,
+
+        [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
+        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenOptions
     )
 
     begin {
         Write-Debug -Message "Entering: $($PSCmdlet.MyInvocation.MyCommand.Name)"
         Assert-InWatchmen -Command $PSCmdlet.MyInvocation.MyCommand.Name
         $global:Watchmen.InNotifies = $true
+
+        if ($global:Watchmen.InConfig) {
+            # If a specific notifier condition is provided, set that in options so subsequent notifiers will inherit the condition
+            $global:Watchmen.Options.NotifierConditions.WatchmenOptions = $When
+
+            Write-Verbose "Default Notifier condition for WatchmenOptions set to $When"
+
+        } elseif ($global:Watchmen.InTest) {
+            # If a specific notifier condition is provided, set that in options so subsequent notifiers within this WatchmenTest
+            # block will inherit the condition
+            $global:Watchmen.Options.NotifierConditions.WatchmenTest = $When
+
+            Write-Verbose "Default Notifier condition for WatchmenTest set to $When"
+        }
     }
 
     process {
-        if ($global:Watchmen.InConfig) {
-            # Add all the notiiers to the Watchmen variable for later use
+        if ($global:Watchmen.InConfig) {        
+            # Add all the notifiers to the Watchmen variable for later use
             Write-Debug -Message 'Adding notifiers to $global:Watchmen.Options.Notifiers'
             $notifiers = . $script
             foreach ($notifier in $notifiers) {

--- a/Watchmen/Public/PowerShell.ps1
+++ b/Watchmen/Public/PowerShell.ps1
@@ -6,7 +6,11 @@ function PowerShell {
 
         #[ValidateScript({Test-Path $_})]
         [parameter(Mandatory, Position = 0, ParameterSetName = 'script')]
-        [string]$Path
+        [string]$Path,
+
+        [parameter(Position = 1)]
+        [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
+        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {
@@ -21,6 +25,7 @@ function PowerShell {
             ScriptBlock = $null
             ScriptPath = $null
             Enabled = $true
+            NotifierCondition = $When
         }
 
         if ($PSCmdlet.ParameterSetName -eq 'ScriptBlock') {

--- a/Watchmen/Public/Slack.ps1
+++ b/Watchmen/Public/Slack.ps1
@@ -2,7 +2,10 @@ function Slack {
     [cmdletbinding()]
     param(
         [parameter(Mandatory, Position = 0)]
-        [hashtable[]]$Options
+        [hashtable[]]$Options,
+
+        [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
+        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {
@@ -25,6 +28,7 @@ function Slack {
             IconUrl =$Options.IconUrl
             IconEmoji = $Options.IconEmoji
             Enabled = $true
+            NotifierCondition = $When
         }
 
         return $e

--- a/Watchmen/Public/Syslog.ps1
+++ b/Watchmen/Public/Syslog.ps1
@@ -2,7 +2,10 @@ function Syslog {
     [cmdletbinding()]
     param(
         [parameter(Mandatory, Position = 0)]
-        [string[]]$Endpoints
+        [string[]]$Endpoints,
+
+        [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
+        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {
@@ -16,6 +19,7 @@ function Syslog {
             Type = 'Syslog' 
             Endpoints = $Endpoints
             Enabled = $true
+            NotifierCondition = $When
         }
 
         return $e

--- a/Watchmen/Public/WatchmenTest.ps1
+++ b/Watchmen/Public/WatchmenTest.ps1
@@ -14,9 +14,12 @@ function WatchmenTest {
 
         # Mark that we are inside an 'WatchmenTest' block and subsequent commands are allowed
         $global:Watchmen.InTest = $true
-    }
 
-    process {
+        # Set the default value for the notifier conditions to what ever has been set in WatchmenOptions
+        # If nothing was specified there, this value will be 'OnFailure'
+        $defaultNotifierCondition = $global:Watchmen.Options.NotifierConditions.WatchmenOptions
+        $global:Watchmen.Options.NotifierConditions.WatchmenTest = $defaultNotifierCondition
+
         $global:Watchmen.ThisTest = @{
             PSTypeName = 'Watchmen.Test'
             ModuleName = $Name
@@ -25,7 +28,7 @@ function WatchmenTest {
             Test = '*'
             Type = 'all'
             Version = $null
-            Notifiers = @{
+            Notifiers = [ordered]@{
                 Email = @()
                 EventLog = @()
                 LogFile = @()
@@ -34,6 +37,9 @@ function WatchmenTest {
                 Syslog = @()
             }
         }
+    }
+
+    process {        
 
         # Execute any functions passed in
         . $Script

--- a/Watchmen/Public/When.ps1
+++ b/Watchmen/Public/When.ps1
@@ -1,0 +1,30 @@
+function When {
+    param(
+        [parameter(Mandatory, Position = 0)]
+        [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
+        [string]$Condition
+    )
+
+    begin {
+        Write-Debug -Message "Entering: $($PSCmdlet.MyInvocation.MyCommand.Name)"
+        Assert-InWatchmen -Command $PSCmdlet.MyInvocation.MyCommand.Name
+    }
+
+    process {
+        if ($global:watchmen.InConfig) {
+            $global:watchmen.Options.NotifierConditions.WatchmenOptions = $Condition
+            $global:watchmen.Options.NotifierConditions.WatchmenTest = $Condition
+
+            Write-Verbose "WatchmenOptions default notifier condition set to $Condition"
+
+        } elseIf ($global:watchmen.InTest) {
+            $global:watchmen.Options.NotifierConditions.WatchmenTest = $Condition
+
+            Write-Verbose "WatchmenTest default notifier condition set to $Condition"
+        }        
+    }
+
+    end {
+        Write-Debug -Message "Exiting: $($PSCmdlet.MyInvocation.MyCommand.Name)"
+    }
+}

--- a/Watchmen/Watchmen.psd1
+++ b/Watchmen/Watchmen.psd1
@@ -72,7 +72,7 @@ FormatsToProcess = 'OperationValidation.Format.ps1xml'
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = 'Email', 'EventLog', 'FromSource', 'Get-WatchmenTest', 
                'Invoke-WatchmenTest', 'LogFile', 'Notifies', 'Parameters', 'PowerShell', 
-               'Slack', 'Syslog', 'Test', 'TestType', 'Version', 
+               'Slack', 'Syslog', 'Test', 'TestType', 'Version', 'When',
                'WatchmenOptions', 'WatchmenTest'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Watchmen/Watchmen.psm1
+++ b/Watchmen/Watchmen.psm1
@@ -23,6 +23,7 @@ $script:CommandFences = @{
         'Version'
     )
     Notifies = @(
+        'When',
         'Notifies',
         'Email',
         'EventLog',

--- a/Watchmen/en-US/Watchmen-help.xml
+++ b/Watchmen/en-US/Watchmen-help.xml
@@ -141,15 +141,23 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 
 </maml:para>
 </maml:Description>
+<command:parameterValueGroup><command:parameterValue required="false" variableLength="false">Always</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnSuccess</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnFailure</command:parameterValue>
+</command:parameterValueGroup>
 <command:parameterValue required="true" variableLength="false">Hashtable</command:parameterValue>
 <dev:type><maml:name>Hashtable</maml:name>
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
+<command:parameterValueGroup><command:parameterValue required="false" variableLength="false">Always</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnSuccess</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnFailure</command:parameterValue>
+</command:parameterValueGroup>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 <dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
@@ -177,7 +185,7 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
@@ -270,9 +278,13 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
+<command:parameterValueGroup><command:parameterValue required="false" variableLength="false">Always</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnSuccess</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnFailure</command:parameterValue>
+</command:parameterValueGroup>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 <dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
@@ -294,7 +306,7 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
@@ -450,9 +462,13 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
+<command:parameterValueGroup><command:parameterValue required="false" variableLength="false">Always</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnSuccess</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnFailure</command:parameterValue>
+</command:parameterValueGroup>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 <dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
@@ -470,7 +486,7 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
@@ -749,9 +765,13 @@ ShortName                   - File name of Pester test
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
+<command:parameterValueGroup><command:parameterValue required="false" variableLength="false">Always</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnSuccess</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnFailure</command:parameterValue>
+</command:parameterValueGroup>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 <dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
@@ -769,9 +789,13 @@ ShortName                   - File name of Pester test
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
+<command:parameterValueGroup><command:parameterValue required="false" variableLength="false">Always</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnSuccess</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnFailure</command:parameterValue>
+</command:parameterValueGroup>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 <dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
@@ -798,7 +822,7 @@ ShortName                   - File name of Pester test
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
@@ -881,9 +905,13 @@ ShortName                   - File name of Pester test
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
+<command:parameterValueGroup><command:parameterValue required="false" variableLength="false">Always</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnSuccess</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnFailure</command:parameterValue>
+</command:parameterValueGroup>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 <dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
@@ -909,7 +937,7 @@ ShortName                   - File name of Pester test
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
@@ -994,9 +1022,13 @@ ShortName                   - File name of Pester test
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
+<command:parameterValueGroup><command:parameterValue required="false" variableLength="false">Always</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnSuccess</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnFailure</command:parameterValue>
+</command:parameterValueGroup>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 <dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
@@ -1014,7 +1046,7 @@ ShortName                   - File name of Pester test
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
 <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
-<maml:Description><maml:para>{{Fill When Description}}
+<maml:Description><maml:para>Specifies when notifier should be executed.
 </maml:para>
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">String</command:parameterValue>

--- a/Watchmen/en-US/Watchmen-help.xml
+++ b/Watchmen/en-US/Watchmen-help.xml
@@ -146,6 +146,15 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
 </command:syntaxItem>
 </command:syntax>
 <command:parameters><command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none"><maml:name>Options</maml:name>
@@ -164,6 +173,15 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">Hashtable</command:parameterValue>
 <dev:type><maml:name>Hashtable</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
@@ -251,6 +269,15 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
 </command:syntaxItem>
 </command:syntax>
 <command:parameters><command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>Options</maml:name>
@@ -263,6 +290,15 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">Hashtable[]</command:parameterValue>
 <dev:type><maml:name>Hashtable[]</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
@@ -413,6 +449,15 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
 </command:syntaxItem>
 </command:syntax>
 <command:parameters><command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none"><maml:name>Path</maml:name>
@@ -421,6 +466,15 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
 <dev:type><maml:name>String[]</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
@@ -493,6 +547,15 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
 </command:syntaxItem>
 </command:syntax>
 <command:parameters><command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none"><maml:name>Script</maml:name>
@@ -501,6 +564,15 @@ subject = 'Watchmen alert - #{computername} - [#{test}] failed!'
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
 <dev:type><maml:name>ScriptBlock</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
@@ -676,6 +748,15 @@ ShortName                   - File name of Pester test
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
 </command:syntaxItem>
 <command:syntaxItem><maml:name>PowerShell</maml:name>
 <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none"><maml:name>ScriptBlock</maml:name>
@@ -684,6 +765,15 @@ ShortName                   - File name of Pester test
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
 <dev:type><maml:name>ScriptBlock</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
@@ -704,6 +794,15 @@ ShortName                   - File name of Pester test
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
 <dev:type><maml:name>ScriptBlock</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
@@ -781,6 +880,15 @@ ShortName                   - File name of Pester test
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
 </command:syntaxItem>
 </command:syntax>
 <command:parameters><command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>Options</maml:name>
@@ -797,6 +905,15 @@ ShortName                   - File name of Pester test
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">Hashtable[]</command:parameterValue>
 <dev:type><maml:name>Hashtable[]</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
@@ -876,6 +993,15 @@ ShortName                   - File name of Pester test
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
 </command:syntaxItem>
 </command:syntax>
 <command:parameters><command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none"><maml:name>Endpoints</maml:name>
@@ -884,6 +1010,15 @@ ShortName                   - File name of Pester test
 </maml:Description>
 <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
 <dev:type><maml:name>String[]</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue></dev:defaultValue>
+</command:parameter>
+<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none"><maml:name>When</maml:name>
+<maml:Description><maml:para>{{Fill When Description}}
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
 <maml:uri /></dev:type>
 <dev:defaultValue></dev:defaultValue>
 </command:parameter>
@@ -1318,6 +1453,77 @@ ShortName                   - File name of Pester test
 </command:examples>
 <command:relatedLinks><maml:navigationLink><maml:linkText>Online Version:</maml:linkText>
 <maml:uri>https://github.com/devblackops/watchmen/blob/master/docs/functions/Help-WatchmenTest.md</maml:uri>
+</maml:navigationLink>
+</command:relatedLinks>
+</command:command>
+<command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+<command:details><command:name>When</command:name>
+<command:verb>When</command:verb>
+<command:noun></command:noun>
+<maml:description><maml:para>Specifies when one or more notifiers should be executed.
+</maml:para>
+</maml:description>
+</command:details>
+<maml:description><maml:para>Specifies when one or more notifiers should be executed.
+</maml:para>
+</maml:description>
+<command:syntax><command:syntaxItem><maml:name>When</maml:name>
+<command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none"><maml:name>Condition</maml:name>
+<maml:Description><maml:para>The condition for when the notifier should be executed.
+</maml:para>
+</maml:Description>
+<command:parameterValueGroup><command:parameterValue required="false" variableLength="false">Always</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnSuccess</command:parameterValue>
+<command:parameterValue required="false" variableLength="false">OnFailure</command:parameterValue>
+</command:parameterValueGroup>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue>OnFailure</dev:defaultValue>
+</command:parameter>
+</command:syntaxItem>
+</command:syntax>
+<command:parameters><command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none"><maml:name>Condition</maml:name>
+<maml:Description><maml:para>The condition for when the notifier should be executed.
+</maml:para>
+</maml:Description>
+<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+<dev:type><maml:name>String</maml:name>
+<maml:uri /></dev:type>
+<dev:defaultValue>OnFailure</dev:defaultValue>
+</command:parameter>
+</command:parameters>
+<command:inputTypes><command:inputType><dev:type><maml:name>None</maml:name>
+</dev:type>
+<maml:description><maml:para>
+</maml:para>
+</maml:description>
+</command:inputType>
+</command:inputTypes>
+<command:returnValues><command:returnValue><dev:type><maml:name>System.Object</maml:name>
+</dev:type>
+<maml:description><maml:para>
+</maml:para>
+</maml:description>
+</command:returnValue>
+</command:returnValues>
+<maml:alertSet><maml:alert><maml:para>
+</maml:para>
+</maml:alert>
+</maml:alertSet>
+<command:examples><command:example><maml:title>Example 1</maml:title>
+<dev:code>WatchmenOptions {
+    notifies {
+        when 'Always'
+    }
+}</dev:code>
+<dev:remarks><maml:para>Tells Watchmen to execute all notifiers regardless if they pass or fail.
+</maml:para>
+</dev:remarks>
+</command:example>
+</command:examples>
+<command:relatedLinks><maml:navigationLink><maml:linkText>Online Version:</maml:linkText>
+<maml:uri>https://github.com/devblackops/watchmen/blob/master/docs/functions/Help-When.md</maml:uri>
 </maml:navigationLink>
 </command:relatedLinks>
 </command:command>

--- a/docs/functions/Help-Email.md
+++ b/docs/functions/Help-Email.md
@@ -10,7 +10,7 @@ Specifies an Email notifier.
 ## SYNTAX
 
 ```
-Email [-Options] <Hashtable> [<CommonParameters>]
+Email [-Options] <Hashtable> [-When <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -90,6 +90,21 @@ Aliases:
 
 Required: True
 Position: 0
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -When
+{{Fill When Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
 Default value: 
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/functions/Help-Email.md
+++ b/docs/functions/Help-Email.md
@@ -86,7 +86,8 @@ Hashtable of values needed to send a SMTP email.
 ```yaml
 Type: Hashtable
 Parameter Sets: (All)
-Aliases: 
+Aliases:
+Accepted values: Always, OnSuccess, OnFailure 
 
 Required: True
 Position: 0
@@ -96,12 +97,13 @@ Accept wildcard characters: False
 ```
 
 ### -When
-{{Fill When Description}}
+Specifies when notifier should be executed.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases: 
+Accepted values: Always, OnSuccess, OnFailure
 
 Required: False
 Position: Named

--- a/docs/functions/Help-EventLog.md
+++ b/docs/functions/Help-EventLog.md
@@ -67,12 +67,13 @@ Accept wildcard characters: False
 ```
 
 ### -When
-{{Fill When Description}}
+Specifies when notifier should be executed.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases: 
+Accepted values: Always, OnSuccess, OnFailure
 
 Required: False
 Position: Named

--- a/docs/functions/Help-EventLog.md
+++ b/docs/functions/Help-EventLog.md
@@ -10,7 +10,7 @@ Specifies an EventLog notifier.
 ## SYNTAX
 
 ```
-EventLog -Options <Hashtable[]> [<CommonParameters>]
+EventLog -Options <Hashtable[]> [-When <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -18,7 +18,6 @@ Specifies an EventLog notifier.
 
 This is not intended to be used anywhere but inside a 'Notifies' block inside a Watchmen file. Directly calling the 'EventLog' function outside of a
 'Notifies' block will throw an error.
-
 ## EXAMPLES
 
 ### Example 1
@@ -61,6 +60,21 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: True
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -When
+{{Fill When Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
 Position: Named
 Default value: 
 Accept pipeline input: False

--- a/docs/functions/Help-FromSource.md
+++ b/docs/functions/Help-FromSource.md
@@ -25,7 +25,6 @@ WatchmenTest 'MyAppOVF' {
 ```
 
 Tells Watchmen to download and install the 'MyAppOVF' module from the public PowerShell Gallery.
-
 ### Example 2
 ```
 WatchmenTest 'MyOVFModule' {
@@ -34,7 +33,6 @@ WatchmenTest 'MyOVFModule' {
 ```
 
 Tells Watchmen to download and install the 'MyAppOVF' module from a private repository called 'PrivateRepository'.
-
 ## PARAMETERS
 
 ### -Source

--- a/docs/functions/Help-LogFile.md
+++ b/docs/functions/Help-LogFile.md
@@ -10,7 +10,7 @@ Specifies a LogFile notifier.
 ## SYNTAX
 
 ```
-LogFile [-Path] <String[]> [<CommonParameters>]
+LogFile [-Path] <String[]> [-When <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -18,7 +18,6 @@ Specifies a LogFile notifier. This command accepts one parameter which is the pa
 
 This is not intended to be used anywhere but inside a 'Notifies' block inside a Watchmen file. Directly calling the 'EventLog' function outside of a
 'Notifies' block will throw an error.
-
 ## EXAMPLES
 
 ### Example 1
@@ -31,7 +30,6 @@ WatchmenTest MyAppOVF {
 ```
 
 Adds a LogFile notifier to a WatchmenTest block.
-
 ### Example2
 ```
 WatchmenOptions {
@@ -45,7 +43,6 @@ WatchmenOptions {
 ```
 
 Adds a LogFile notifier to a WatchmenOptions block.
-
 ## PARAMETERS
 
 ### -Path
@@ -58,6 +55,21 @@ Aliases:
 
 Required: True
 Position: 0
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -When
+{{Fill When Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
 Default value: 
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/functions/Help-LogFile.md
+++ b/docs/functions/Help-LogFile.md
@@ -61,12 +61,13 @@ Accept wildcard characters: False
 ```
 
 ### -When
-{{Fill When Description}}
+Specifies when notifier should be executed.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases: 
+Accepted values: Always, OnSuccess, OnFailure
 
 Required: False
 Position: Named

--- a/docs/functions/Help-Notifies.md
+++ b/docs/functions/Help-Notifies.md
@@ -10,7 +10,7 @@ Specifies one or more notifiers to be executed upon any failing tests.
 ## SYNTAX
 
 ```
-Notifies [-Script] <ScriptBlock> [<CommonParameters>]
+Notifies [-Script] <ScriptBlock> [-When <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -48,7 +48,6 @@ WatchmenOptions {
 ```
 
 Specifies various notifiers to be executed upon any failing tests.
-
 ## PARAMETERS
 
 ### -Script
@@ -61,6 +60,21 @@ Aliases:
 
 Required: True
 Position: 0
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -When
+{{Fill When Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
 Default value: 
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/functions/Help-Parameters.md
+++ b/docs/functions/Help-Parameters.md
@@ -1,6 +1,6 @@
 ﻿---
 external help file: Watchmen-help.xml
-online version: https://github.com/devblackops/watchmen/blob/master/docs/functions/Help-Parameters.md 
+online version: https://github.com/devblackops/watchmen/blob/master/docs/functions/Help-Parameters.md
 schema: 2.0.0
 ---
 
@@ -28,7 +28,6 @@ WatchmenTest 'MyAppOVF' {
 ```
 
 Defines a Watchmen test to execute the OVF module 'MyAppOVF' and pass the parameter 'FreeSpaceThreshold' to the Pester test inside the OVF module.
-
 ## PARAMETERS
 
 ### -Parameters

--- a/docs/functions/Help-PowerShell.md
+++ b/docs/functions/Help-PowerShell.md
@@ -106,12 +106,13 @@ Accept wildcard characters: False
 ```
 
 ### -When
-{{Fill When Description}}
+Specifies when notifier should be executed.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases: 
+Accepted values: Always, OnSuccess, OnFailure
 
 Required: False
 Position: Named

--- a/docs/functions/Help-PowerShell.md
+++ b/docs/functions/Help-PowerShell.md
@@ -1,4 +1,4 @@
----
+﻿---
 external help file: Watchmen-help.xml
 online version: https://github.com/devblackops/watchmen/blob/master/docs/functions/Help-PowerShell.md
 schema: 2.0.0
@@ -7,17 +7,16 @@ schema: 2.0.0
 # PowerShell
 ## SYNOPSIS
 Specifies an PowerShell notifier.
-
 ## SYNTAX
 
 ### ScriptBlock (Default)
 ```
-PowerShell [-ScriptBlock] <ScriptBlock>
+PowerShell [-ScriptBlock] <ScriptBlock> [-When <String>] [<CommonParameters>]
 ```
 
-### Script
+### script
 ```
-PowerShell [-Path] <String>
+PowerShell [-Path] <String> [-When <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -51,8 +50,6 @@ RawResult
     Time                    - Time Pester test took to execute  
 Result                      - Pass or fail status of test. Values are [Passed] or [Failed]  
 ShortName                   - File name of Pester test  
-
-
 ## EXAMPLES
 
 ### Example 1
@@ -66,16 +63,16 @@ WatchmenOptions {
 
 Adds a PowerShell notifier to a WatchmenOptions block. This PowerShell script block will display a message using values contains withing test result
 object.
-
 ### Example 2
 ```
 WatchmenTest {
     powershell '\notifier.ps1'
 }
-``` 
+```
+
+ 
 
 Adds a PowerShell notifier to an individual Watchmen test. This PowerShell notifier will execute the 'notifier.ps1' script.
-
 ## PARAMETERS
 
 ### -Path
@@ -108,10 +105,26 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -When
+{{Fill When Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 ## INPUTS
 
 ### None
-
 
 ## OUTPUTS
 

--- a/docs/functions/Help-Slack.md
+++ b/docs/functions/Help-Slack.md
@@ -7,11 +7,10 @@ schema: 2.0.0
 # Slack
 ## SYNOPSIS
 Specifies an EventLog notifier.
-
 ## SYNTAX
 
 ```
-Slack -Options <Hashtable[]> [<CommonParameters>]
+Slack -Options <Hashtable[]> [-When <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -19,7 +18,6 @@ Specifies an Slack notifier.
 
 This is not intended to be used anywhere but inside a 'Notifies' block inside a Watchmen file. Directly calling the 'Slack' function outside of a
 'Notifies' block will throw an error.
-
 ## EXAMPLES
 
 ### Example 1
@@ -37,9 +35,7 @@ WatchmenOptions {
 
 Adds a Slack notifier to a WatchmenOptions block. The hashtable specified includes all the required parameters to send a Slack message using
 the PSSlack module.
-
 ### Example 2
-
 ```
 WatchmenTest {
     slack @{
@@ -54,7 +50,6 @@ WatchmenTest {
 
 Adds a Slack notifier to a WatchmenTest block. The hashtable specified includes all the required parameters to send a Slack message using
 the PSSlack module.
-
 ## PARAMETERS
 
 ### -Options
@@ -73,6 +68,21 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: True
+Position: Named
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -When
+{{Fill When Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
 Position: Named
 Default value: 
 Accept pipeline input: False

--- a/docs/functions/Help-Slack.md
+++ b/docs/functions/Help-Slack.md
@@ -75,12 +75,13 @@ Accept wildcard characters: False
 ```
 
 ### -When
-{{Fill When Description}}
+Specifies when notifier should be executed.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases: 
+Accepted values: Always, OnSuccess, OnFailure
 
 Required: False
 Position: Named

--- a/docs/functions/Help-Syslog.md
+++ b/docs/functions/Help-Syslog.md
@@ -10,7 +10,7 @@ Specifies a Syslog notifier.
 ## SYNTAX
 
 ```
-Syslog [-Endpoints] <String[]> [<CommonParameters>]
+Syslog [-Endpoints] <String[]> [-When <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -18,7 +18,6 @@ Specifies a Syslog notifier. This command accepts one parameter which is the IP 
 
 This is not intended to be used anywhere but inside a 'Notifies' block inside a Watchmen file. Directly calling the 'Syslog' function outside of a
 'Notifies' block will throw an error.
-
 ## EXAMPLES
 
 ### Example 1
@@ -31,7 +30,6 @@ WatchmenTest MyAppOVF {
 ```
 
 Adds a Syslog notifier to a WatchmenTest block.
-
 ### Example2
 ```
 WatchmenOptions {
@@ -42,7 +40,6 @@ WatchmenOptions {
 ```
 
 Adds a Syslog notifier to a WatchmenOptions block.
-
 ## PARAMETERS
 
 ### -Endpoints
@@ -55,6 +52,21 @@ Aliases:
 
 Required: True
 Position: 0
+Default value: 
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -When
+{{Fill When Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
 Default value: 
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/functions/Help-Syslog.md
+++ b/docs/functions/Help-Syslog.md
@@ -58,12 +58,13 @@ Accept wildcard characters: False
 ```
 
 ### -When
-{{Fill When Description}}
+Specifies when notifier should be executed.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases: 
+Accepted values: Always, OnSuccess, OnFailure
 
 Required: False
 Position: Named

--- a/docs/functions/Help-Test.md
+++ b/docs/functions/Help-Test.md
@@ -7,7 +7,6 @@ schema: 2.0.0
 # Test
 ## SYNOPSIS
 Specifies the 'Describe' block in a Pester test to execute.
-
 ## SYNTAX
 
 ```
@@ -17,7 +16,6 @@ Test [[-Test] <String>] [<CommonParameters>]
 ## DESCRIPTION
 Specifies the 'Describe' block in a Pester test to execute. Pester / OVF tests can include multiple 'Describe' blocks to logically seperate
 tests. This parameter allows you to only execute the designated 'Describe' block name.
-
 ## EXAMPLES
 
 ### Example 1
@@ -28,7 +26,6 @@ WatchmenTest 'MyAppOVF' {
 ```
 
 Tells Watchmen to only execute tests within the 'Describe' block 'Services' inside the OVF module 'MyAppOVF.'
-
 ## PARAMETERS
 
 ### -Test

--- a/docs/functions/Help-TestType.md
+++ b/docs/functions/Help-TestType.md
@@ -7,7 +7,6 @@ schema: 2.0.0
 # TestType
 ## SYNOPSIS
 Specifies the OVF test type to execute. This may be 'Simple', 'Comprehensive', or 'All'.
-
 ## SYNTAX
 
 ```
@@ -16,7 +15,6 @@ TestType [-Type] <String> [<CommonParameters>]
 
 ## DESCRIPTION
 Specifies the OVF test type to execute. This may be 'Simple', 'Comprehensive', or 'All'. 'All' is the default if not specified.
-
 ## EXAMPLES
 
 ### Example 1
@@ -27,7 +25,6 @@ WatchmenTest 'MyAppOVF' {
 ```
 
 Tells Watchmen to only execute 'Simple' tests within the 'MyAppOVF' module.
-
 ### Example 2
 ```
 WatchmenTest 'MyAppOVF' {
@@ -36,7 +33,6 @@ WatchmenTest 'MyAppOVF' {
 ```
 
 Tells Watchmen to only execute 'Comprehensive' tests within the 'MyAppOVF' module.
-
 ## PARAMETERS
 
 ### -Type

--- a/docs/functions/Help-Version.md
+++ b/docs/functions/Help-Version.md
@@ -7,7 +7,6 @@ schema: 2.0.0
 # Version
 ## SYNOPSIS
 Specifies the version of the OVF module to execute tests from.
-
 ## SYNTAX
 
 ```
@@ -17,7 +16,6 @@ Version [-Version] <String> [<CommonParameters>]
 ## DESCRIPTION
 Specifies the version of the OVF module to execute tests from. Since OVF tests are normal PowerShell modules, multiple versions of the module are
 allowed to be installed on the system. If this parameter is not specified, the latest version of the module will be used.
-
 ## EXAMPLES
 
 ### Example 1
@@ -28,7 +26,6 @@ WatchmenTest 'MyAppOVF' {
 ```
 
 Teslls Watchmen to execute tests from version 1.2.3 of the 'MyAppOVF' module.
-
 ## PARAMETERS
 
 ### -Version

--- a/docs/functions/Help-WatchmenOptions.md
+++ b/docs/functions/Help-WatchmenOptions.md
@@ -7,7 +7,6 @@ schema: 2.0.0
 # WatchmenOptions
 ## SYNOPSIS
 Specifies a global set of options that subsequent Watchmen tests will inherit from.
-
 ## SYNTAX
 
 ```
@@ -17,7 +16,6 @@ WatchmenOptions [[-Script] <ScriptBlock>] [<CommonParameters>]
 ## DESCRIPTION
 Specifies a global set of options that subsequent Watchmen tests will inherit from. Specifing notifiers within the WatchmenOptions block allows
 all subsequent Watchmen tests to use those notifiers in addition to any defined directly on the Watchmen test.
-
 ## EXAMPLES
 
 ### Example 1
@@ -54,7 +52,6 @@ WatchmenOptions {
 
 This defines a set of notifiers that will be executed upon any failing Watching tests. All Watchmen tests will execute notifiers specified in
 WatchmenOptions in addition to any specified directly on the Watchmen test.
-
 ## PARAMETERS
 
 ### -Script

--- a/docs/functions/Help-WatchmenTest.md
+++ b/docs/functions/Help-WatchmenTest.md
@@ -7,7 +7,6 @@ schema: 2.0.0
 # WatchmenTest
 ## SYNOPSIS
 Specifies an OVF module to execute Pester tests from.
-
 ## SYNTAX
 
 ### NoName (Default)
@@ -23,7 +22,6 @@ WatchmenTest [[-Name] <String>] [-Script] <ScriptBlock> [<CommonParameters>]
 ## DESCRIPTION
 Specifies an OVF module to execute Pester tests from. Optional properties are specified to execute a specific OVF module version, test name or type,
 override parameters from Pester tests, and to execute notifiers upon any failing tests.
-
 ## EXAMPLES
 
 ### Example 1
@@ -46,7 +44,6 @@ Execute Pester tests from version 1.0.0 of module 'MyAppOVF.' Also only run the 
 module and/or version is not installed on the system, then download the module from the 'PSGallery' PowerShell repository. When the test is executed,
 insert the parameter 'FreeSystemDriveThreshold' into the Pester test to override any default value for that parameter. Upon a failing test, execute
 the 'Logfile' notifier and write an entry to the log file located on a file share.
-
 ## PARAMETERS
 
 ### -Name

--- a/docs/functions/Help-When.md
+++ b/docs/functions/Help-When.md
@@ -1,0 +1,61 @@
+﻿---
+external help file: Watchmen-help.xml
+online version: https://github.com/devblackops/watchmen/blob/master/docs/functions/Help-When.md
+schema: 2.0.0
+---
+
+# When
+## SYNOPSIS
+Specifies when one or more notifiers should be executed.
+## SYNTAX
+
+```
+When [-Condition] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Specifies when one or more notifiers should be executed.
+## EXAMPLES
+
+### Example 1
+```
+WatchmenOptions {
+    notifies {
+        when 'Always'
+    }
+}
+```
+
+Tells Watchmen to execute all notifiers regardless if they pass or fail.
+## PARAMETERS
+
+### -Condition
+The condition for when the notifier should be executed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+Accepted values: Always, OnSuccess, OnFailure
+
+Required: True
+Position: 0
+Default value: OnFailure
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+

--- a/psake.ps1
+++ b/psake.ps1
@@ -57,10 +57,10 @@ task GenerateHelp -Depends Init {
 }
 
 task ExportFunctions {
-    $files = Get-ChildItem -Path $sut\Public | Select -ExpandProperty Name
+    $files = Get-ChildItem -Path $sut\Public | Select-Object -ExpandProperty Name
     $functions = @()
-    $files | % {
-        $functions += $_.Split('.')[0]
+    foreach ($file in $files) {
+        $functions += $file.Split('.')[0]
     }
     Update-ModuleManifest -Path $sut\Watchmen.psd1 -FunctionsToExport $functions
 }


### PR DESCRIPTION
Adds ability to specify conditions when notifiers will be executed.
## Description

There may be cases where you want certain notifiers to be called even for successful Pester tests. This PR adds a new parameter to every notifier controlling when the notifier will be executed (Always, OnFailure, and OnSuccess).

A new parameter `-When` has been added to each notifier function as well as a new function called `When` that is available under the `Notifies` block to set the default condition for all notifiers. The default option for the `-When` parameter is `OnFailure`. Omitting this parameter would not change how Watchmen currently behaves.
## Related Issue
#3
## Motivation and Context

Watchmen currently only executes notifiers on test failures. There are some workflows where it is desirable to execute certain notifiers even for successful Pester tests.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
