### PR TITLE
Move Watchmen object into script scope instead of global scope.

### DIFF
--- a/Tests/Public/FromSource.tests.ps1
+++ b/Tests/Public/FromSource.tests.ps1
@@ -6,13 +6,13 @@ InModuleScope Watchmen {
         Mock -CommandName Assert-InWatchmen -MockWith {}
 
         it 'Creates a [FromSource] entry in the Watchmen variable' {
-            $global:watchmen = @{
+            $script:watchmen = @{
                 ThisTest = @{
                     Source = $null
                 }
             }
             FromSource 'PSGallery'
-            $global:watchmen.ThisTest.Source | should be 'PSGallery'
+            $script:watchmen.ThisTest.Source | should be 'PSGallery'
         }
     }
 }

--- a/Tests/Public/Notifies.tests.ps1
+++ b/Tests/Public/Notifies.tests.ps1
@@ -53,27 +53,27 @@ InModuleScope Watchmen {
         }
 
         it 'Email notifier defined' {
-            $global:Watchmen.Options.Notifiers.email | should not benullorempty
+            $script:Watchmen.Options.Notifiers.email | should not benullorempty
         }
 
         it 'Eventlog notifier defined' {
-            $global:Watchmen.Options.Notifiers.eventlog | should not benullorempty
+            $script:Watchmen.Options.Notifiers.eventlog | should not benullorempty
         }
 
         it 'LogFile notifier defined' {
-            $global:Watchmen.Options.Notifiers.logfile | should not benullorempty
+            $script:Watchmen.Options.Notifiers.logfile | should not benullorempty
         }
 
         it 'PowerShell notifier defined' {
-            $global:Watchmen.Options.Notifiers.powershell | should not benullorempty
+            $script:Watchmen.Options.Notifiers.powershell | should not benullorempty
         }
 
         it 'Slack notifier defined' {
-            $global:Watchmen.Options.Notifiers.slack | should not benullorempty
+            $script:Watchmen.Options.Notifiers.slack | should not benullorempty
         }
 
         it 'Syslog notifier defined' {
-            $global:Watchmen.Options.Notifiers.syslog | should not benullorempty
+            $script:Watchmen.Options.Notifiers.syslog | should not benullorempty
         }
     }
 }

--- a/Tests/Public/Parameters.tests.ps1
+++ b/Tests/Public/Parameters.tests.ps1
@@ -6,13 +6,13 @@ InModuleScope Watchmen {
         Mock -CommandName Assert-InWatchmen -MockWith {}
 
         it 'Creates a [Parameters] entry in the Watchmen variable' {
-            $global:watchmen = @{
+            $script:watchmen = @{
                 ThisTest = @{
                     Parameters = $null
                 }
             }
             Parameters @{ foo = 'bar' }
-            $global:watchmen.ThisTest.Parameters.foo | should be 'bar'
+            $script:watchmen.ThisTest.Parameters.foo | should be 'bar'
         }
     }
 }

--- a/Tests/Public/Test.tests.ps1
+++ b/Tests/Public/Test.tests.ps1
@@ -6,13 +6,13 @@ InModuleScope Watchmen {
         Mock -CommandName Assert-InWatchmen -MockWith {}
 
         it 'Creates a [Test] entry in the Watchmen variable' {
-            $global:watchmen = @{
+            $script:watchmen = @{
                 ThisTest = @{
                     Test = $null
                 }
             }
             Test 'services'
-            $global:watchmen.ThisTest.Test | should be 'services'
+            $script:watchmen.ThisTest.Test | should be 'services'
         }
     }
 }

--- a/Tests/Public/TestType.tests.ps1
+++ b/Tests/Public/TestType.tests.ps1
@@ -6,13 +6,13 @@ InModuleScope Watchmen {
         Mock -CommandName Assert-InWatchmen -MockWith {}
 
         it 'Creates a [TestType] entry in the Watchmen variable' {
-            $global:watchmen = @{
+            $script:watchmen = @{
                 ThisTest = @{
                     TestType = $null
                 }
             }
             TestType 'simple'
-            $global:watchmen.ThisTest.Type | should be 'simple'
+            $script:watchmen.ThisTest.Type | should be 'simple'
         }
     }
 }

--- a/Tests/Public/Version.ps1
+++ b/Tests/Public/Version.ps1
@@ -6,13 +6,13 @@ InModuleScope Watchmen {
         Mock -CommandName Assert-InWatchmen -MockWith {}
 
         it 'Creates a [Version] entry in the Watchmen variable' {
-            $global:watchmen = @{
+            $script:watchmen = @{
                 ThisTest = @{
                     Version = $null
                 }
             }
             Version '0.1.0'
-            $global:watchmen.ThisTest.Version | should be '0.1.0'
+            $script:watchmen.ThisTest.Version | should be '0.1.0'
         }
     }
 }

--- a/Tests/Public/When.tests.ps1
+++ b/Tests/Public/When.tests.ps1
@@ -8,7 +8,7 @@ InModuleScope Watchmen {
             Mock -CommandName Assert-InWatchmen -MockWith {}
 
             BeforeEach {
-                $global:watchmen = @{
+                $script:watchmen = @{
                     InConfig = $true
                     InTest = $false
                     Options = @{
@@ -22,20 +22,20 @@ InModuleScope Watchmen {
 
             it 'Sets the default notifier condition to [OnFailure]' {
                 When 'OnFailure'
-                $global:Watchmen.Options.NotifierConditions.WatchmenOptions | should be 'Onfailure'
-                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Onfailure'
+                $script:Watchmen.Options.NotifierConditions.WatchmenOptions | should be 'Onfailure'
+                $script:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Onfailure'
             }
 
             it 'Sets the default notifier condition to [OnSuccess]' {
                 When 'OnSuccess'
-                $global:Watchmen.Options.NotifierConditions.WatchmenOptions | should be 'OnSuccess'
-                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'OnSuccess'
+                $script:Watchmen.Options.NotifierConditions.WatchmenOptions | should be 'OnSuccess'
+                $script:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'OnSuccess'
             }
 
             it 'Sets the default notifier condition to [Always]' {
                 When 'Always'
-                $global:Watchmen.Options.NotifierConditions.WatchmenOptions | should be 'Always'
-                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Always'
+                $script:Watchmen.Options.NotifierConditions.WatchmenOptions | should be 'Always'
+                $script:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Always'
             }
         }
 
@@ -44,7 +44,7 @@ InModuleScope Watchmen {
             Mock -CommandName Assert-InWatchmen -MockWith {}
 
             BeforeEach {
-                $global:watchmen = @{
+                $script:watchmen = @{
                     InConfig = $false
                     InTest = $true
                     Options = @{
@@ -58,17 +58,17 @@ InModuleScope Watchmen {
 
             it 'Sets the default notifier condition to [OnFailure]' {
                 When 'OnFailure'
-                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Onfailure'
+                $script:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Onfailure'
             }
 
             it 'Sets the default notifier condition to [OnSuccess]' {
                 When 'OnSuccess'
-                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'OnSuccess'
+                $script:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'OnSuccess'
             }
 
             it 'Sets the default notifier condition to [Always]' {
                 When 'Always'
-                $global:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Always'
+                $script:Watchmen.Options.NotifierConditions.WatchmenTest | should be 'Always'
             }
         }
     }

--- a/Watchmen/Private/Assert-InWatchmen.ps1
+++ b/Watchmen/Private/Assert-InWatchmen.ps1
@@ -2,13 +2,13 @@ function Assert-InWatchmen {
     param ($Command)
 
     # Verify we aren't calling the command completly outside of a Watchmen file
-    if ($null -eq $global:Watchmen) {
+    if ($null -eq $script:Watchmen) {
         throw "The command [$Command] may only be used inside a Watchmen configuration file."
     }
 
     # WatchmenOptions
-    if ($global:Watchmen.InConfig) {
-        if ($global:Watchmen.InNotifies) {
+    if ($script:Watchmen.InConfig) {
+        if ($script:Watchmen.InNotifies) {
             if ($command -notin $script:CommandFences.Notifies) {
                 throw "The Watchmen command [$Command] may only be used inside a Notifies block."
             }
@@ -20,9 +20,9 @@ function Assert-InWatchmen {
     }
 
     # WatchmenTest
-    if ($global:WatchMen.InTest) {
+    if ($script:WatchMen.InTest) {
 
-        if ($global:Watchmen.InNotifies) {
+        if ($script:Watchmen.InNotifies) {
             if ($command -notin $script:CommandFences.Notifies) {
                 throw "The Watchmen command [$Command] may only be used inside a Notifies block."
             }
@@ -34,7 +34,7 @@ function Assert-InWatchmen {
     }
 
     # Notifies
-    if ($global:WatchMen.InNotifies) {
+    if ($script:WatchMen.InNotifies) {
         if ($command -notin $script:CommandFences.Notifies) {
             throw "The Watchmen command [$Command] may only be used inside a Notifies block."
         }

--- a/Watchmen/Private/Initialize-Watchmen.ps1
+++ b/Watchmen/Private/Initialize-Watchmen.ps1
@@ -7,7 +7,7 @@ function Initialize-Watchmen {
 
     $defaultNotifierCondition = 'OnFailure'
 
-    $global:Watchmen = [pscustomobject]@{
+    $script:Watchmen = [pscustomobject]@{
         PSTypeName = 'Watchmen.State'
         CurrentTestSetId = 0
         InConfig = $false
@@ -46,5 +46,5 @@ function Initialize-Watchmen {
         )
     }
 
-    Write-Verbose "NotifierConditions initialized:`n$($global:watchmen.options.notifierconditions | ft | out-string)"
+    Write-Verbose "NotifierConditions initialized:`n$($script:watchmen.Options.NotifierConditions | Format-Table -Property * | Out-String)"
 }

--- a/Watchmen/Public/Email.ps1
+++ b/Watchmen/Public/Email.ps1
@@ -5,7 +5,7 @@ function Email {
         [hashtable]$Options,
 
         [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
-        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
+        [string]$When = $script:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {

--- a/Watchmen/Public/EventLog.ps1
+++ b/Watchmen/Public/EventLog.ps1
@@ -5,7 +5,7 @@ function EventLog {
         [hashtable[]]$Options,
 
         [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
-        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
+        [string]$When = $script:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {

--- a/Watchmen/Public/Get-WatchmenTest.ps1
+++ b/Watchmen/Public/Get-WatchmenTest.ps1
@@ -19,10 +19,10 @@ function Get-WatchmenTest {
                 $item = Get-Item -Path (Resolve-Path $loc)
                 if ($item.PSIsContainer) {
                     $files = Get-ChildItem -Path $item -Filter '*.watchmen.ps1' -Recurse:$Recurse
-                    $global:watchmen.CurrentWatchmenFileRoot = $item.FullName
+                    $script:watchmen.CurrentWatchmenFileRoot = $item.FullName
                 } else {
                     $files = $item
-                    $global:watchmen.CurrentWatchmenFileRoot = $item.Directory
+                    $script:watchmen.CurrentWatchmenFileRoot = $item.Directory
                 }
 
                 $tests = @()
@@ -32,7 +32,7 @@ function Get-WatchmenTest {
                     $fileTests += . $file.FullName
 
                     $tests += $fileTests
-                    $global:watchmen.TestSets += $fileTests
+                    $script:watchmen.TestSets += $fileTests
                 }
 
                 $tests

--- a/Watchmen/Public/LogFile.ps1
+++ b/Watchmen/Public/LogFile.ps1
@@ -5,7 +5,7 @@ function LogFile {
         [string[]]$Path,
 
         [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
-        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
+        [string]$When = $script:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {

--- a/Watchmen/Public/Notifies.ps1
+++ b/Watchmen/Public/Notifies.ps1
@@ -4,49 +4,49 @@ function Notifies {
         [scriptblock]$Script,
 
         [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
-        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenOptions
+        [string]$When = $script:Watchmen.Options.NotifierConditions.WatchmenOptions
     )
 
     begin {
         Write-Debug -Message "Entering: $($PSCmdlet.MyInvocation.MyCommand.Name)"
         Assert-InWatchmen -Command $PSCmdlet.MyInvocation.MyCommand.Name
-        $global:Watchmen.InNotifies = $true
+        $script:Watchmen.InNotifies = $true
 
-        if ($global:Watchmen.InConfig) {
+        if ($script:Watchmen.InConfig) {
             # If a specific notifier condition is provided, set that in options so subsequent notifiers will inherit the condition
-            $global:Watchmen.Options.NotifierConditions.WatchmenOptions = $When
+            $script:Watchmen.Options.NotifierConditions.WatchmenOptions = $When
 
             Write-Verbose "Default Notifier condition for WatchmenOptions set to $When"
 
-        } elseif ($global:Watchmen.InTest) {
+        } elseif ($script:Watchmen.InTest) {
             # If a specific notifier condition is provided, set that in options so subsequent notifiers within this WatchmenTest
             # block will inherit the condition
-            $global:Watchmen.Options.NotifierConditions.WatchmenTest = $When
+            $script:Watchmen.Options.NotifierConditions.WatchmenTest = $When
 
             Write-Verbose "Default Notifier condition for WatchmenTest set to $When"
         }
     }
 
     process {
-        if ($global:Watchmen.InConfig) {        
+        if ($script:Watchmen.InConfig) {        
             # Add all the notifiers to the Watchmen variable for later use
-            Write-Debug -Message 'Adding notifiers to $global:Watchmen.Options.Notifiers'
+            Write-Debug -Message 'Adding notifiers to $script:Watchmen.Options.Notifiers'
             $notifiers = . $script
             foreach ($notifier in $notifiers) {
-                $global:Watchmen.Options.Notifiers.($Notifier.Type) += $Notifier
+                $script:Watchmen.Options.Notifiers.($Notifier.Type) += $Notifier
             }
-        } elseif ($global:Watchmen.InTest) {
+        } elseif ($script:Watchmen.InTest) {
             # Add locally defined notifiers to the test
-            Write-Debug -Message 'Adding notifiers to $global:Watchmen.ThisTest.Notifiers'
+            Write-Debug -Message 'Adding notifiers to $script:Watchmen.ThisTest.Notifiers'
             $notifiers = . $script
             foreach ($notifier in $notifiers) {
-                $global:Watchmen.ThisTest.Notifiers.($Notifier.Type) += $Notifier
+                $script:Watchmen.ThisTest.Notifiers.($Notifier.Type) += $Notifier
             }
         }
     }
 
     end {
-        $global:Watchmen.InNotifies = $false
+        $script:Watchmen.InNotifies = $false
         Write-Debug -Message "Exiting: $($PSCmdlet.MyInvocation.MyCommand.Name)"
     }
 }

--- a/Watchmen/Public/PowerShell.ps1
+++ b/Watchmen/Public/PowerShell.ps1
@@ -10,7 +10,7 @@ function PowerShell {
 
         [parameter(Position = 1)]
         [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
-        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
+        [string]$When = $script:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {
@@ -37,7 +37,7 @@ function PowerShell {
             if ([System.IO.Path]::IsPathRooted($path)) {
                 $file = Get-Item -Path $resolvedPath
             } else {
-                $file = Get-Item -Path (Join-Path -Path $Global:Watchmen.CurrentWatchmenFileRoot -ChildPath $Path)
+                $file = Get-Item -Path (Join-Path -Path $script:Watchmen.CurrentWatchmenFileRoot -ChildPath $Path)
             }
 
             if (-not $file.PSIsContainer) {

--- a/Watchmen/Public/Slack.ps1
+++ b/Watchmen/Public/Slack.ps1
@@ -5,7 +5,7 @@ function Slack {
         [hashtable[]]$Options,
 
         [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
-        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
+        [string]$When = $script:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {

--- a/Watchmen/Public/Syslog.ps1
+++ b/Watchmen/Public/Syslog.ps1
@@ -5,7 +5,7 @@ function Syslog {
         [string[]]$Endpoints,
 
         [ValidateSet('Always', 'OnSuccess', 'OnFailure')]
-        [string]$When = $global:Watchmen.Options.NotifierConditions.WatchmenTest
+        [string]$When = $script:Watchmen.Options.NotifierConditions.WatchmenTest
     )
 
     begin {

--- a/Watchmen/Public/TestType.ps1
+++ b/Watchmen/Public/TestType.ps1
@@ -11,7 +11,7 @@ function TestType {
     }
 
     process {
-        $global:watchmen.ThisTest.Type = $Type
+        $script:watchmen.ThisTest.Type = $Type
     }
 
     end {

--- a/Watchmen/Public/WatchmenOptions.ps1
+++ b/Watchmen/Public/WatchmenOptions.ps1
@@ -7,7 +7,7 @@ function WatchmenOptions {
     begin {
         Write-Debug -Message "Entering: $($PSCmdlet.MyInvocation.MyCommand.Name)"
         # Mark that we are inside an 'WatchmenOptions' block and subsequent commands are allowed
-        $global:Watchmen.InConfig = $true
+        $script:Watchmen.InConfig = $true
     }
 
     process {
@@ -17,7 +17,7 @@ function WatchmenOptions {
 
     end {
         # Mark that we have exited the 'WatchmenOptions' block
-        $global:Watchmen.InConfig = $false
+        $script:Watchmen.InConfig = $false
 
         Write-Debug -Message "Exiting: $($PSCmdlet.MyInvocation.MyCommand.Name)"
     }

--- a/Watchmen/Public/WatchmenTest.ps1
+++ b/Watchmen/Public/WatchmenTest.ps1
@@ -13,14 +13,14 @@ function WatchmenTest {
         Write-Debug -Message "Entering: $($PSCmdlet.MyInvocation.MyCommand.Name)"
 
         # Mark that we are inside an 'WatchmenTest' block and subsequent commands are allowed
-        $global:Watchmen.InTest = $true
+        $script:Watchmen.InTest = $true
 
         # Set the default value for the notifier conditions to what ever has been set in WatchmenOptions
         # If nothing was specified there, this value will be 'OnFailure'
-        $defaultNotifierCondition = $global:Watchmen.Options.NotifierConditions.WatchmenOptions
-        $global:Watchmen.Options.NotifierConditions.WatchmenTest = $defaultNotifierCondition
+        $defaultNotifierCondition = $script:Watchmen.Options.NotifierConditions.WatchmenOptions
+        $script:Watchmen.Options.NotifierConditions.WatchmenTest = $defaultNotifierCondition
 
-        $global:Watchmen.ThisTest = @{
+        $script:Watchmen.ThisTest = @{
             PSTypeName = 'Watchmen.Test'
             ModuleName = $Name
             parameters = @{}
@@ -45,14 +45,14 @@ function WatchmenTest {
         . $Script
 
         # Add any global notifiers to the test
-        foreach ($key in $global:Watchmen.Options.Notifiers.Keys) {
-            $globalNotifier = $global:Watchmen.Options.Notifiers.($key)
+        foreach ($key in $script:Watchmen.Options.Notifiers.Keys) {
+            $globalNotifier = $script:Watchmen.Options.Notifiers.($key)
             if ($globalNotifier.Count -gt 0) {
-                $global:Watchmen.ThisTest.Notifiers.($key) += $globalNotifier
+                $script:Watchmen.ThisTest.Notifiers.($key) += $globalNotifier
             }
         }
 
-        $t = [pscustomobject]$global:watchmen.ThisTest
+        $t = [pscustomobject]$script:watchmen.ThisTest
         Write-Verbose -Message "Created Watchmen test [$($t.ModuleName)[$($t.Test)]]"
 
         return $t
@@ -60,7 +60,7 @@ function WatchmenTest {
 
     end {
         # Mark that we have exited the 'WatchmenTest' block
-        $global:Watchmen.InTest = $false
+        $script:Watchmen.InTest = $false
 
         Write-Debug -Message "Exiting: $($PSCmdlet.MyInvocation.MyCommand.Name)"
     }

--- a/Watchmen/Public/When.ps1
+++ b/Watchmen/Public/When.ps1
@@ -11,14 +11,14 @@ function When {
     }
 
     process {
-        if ($global:watchmen.InConfig) {
-            $global:watchmen.Options.NotifierConditions.WatchmenOptions = $Condition
-            $global:watchmen.Options.NotifierConditions.WatchmenTest = $Condition
+        if ($script:watchmen.InConfig) {
+            $script:watchmen.Options.NotifierConditions.WatchmenOptions = $Condition
+            $script:watchmen.Options.NotifierConditions.WatchmenTest = $Condition
 
             Write-Verbose "WatchmenOptions default notifier condition set to $Condition"
 
-        } elseIf ($global:watchmen.InTest) {
-            $global:watchmen.Options.NotifierConditions.WatchmenTest = $Condition
+        } elseIf ($script:watchmen.InTest) {
+            $script:watchmen.Options.NotifierConditions.WatchmenTest = $Condition
 
             Write-Verbose "WatchmenTest default notifier condition set to $Condition"
         }        

--- a/Watchmen/Public/fromsource.ps1
+++ b/Watchmen/Public/fromsource.ps1
@@ -11,7 +11,7 @@ function FromSource {
     }
 
     process {
-        $global:watchmen.ThisTest.Source = $Source
+        $script:watchmen.ThisTest.Source = $Source
     }
 
     end {

--- a/Watchmen/Public/parameters.ps1
+++ b/Watchmen/Public/parameters.ps1
@@ -10,7 +10,7 @@ function Parameters {
     }
 
     process {
-        $global:watchmen.ThisTest.Parameters = $Parameters
+        $script:watchmen.ThisTest.Parameters = $Parameters
     }
 
     end {

--- a/Watchmen/Public/test.ps1
+++ b/Watchmen/Public/test.ps1
@@ -10,7 +10,7 @@ function Test {
     }
 
     process {
-        $global:watchmen.ThisTest.Test = $Test
+        $script:watchmen.ThisTest.Test = $Test
     }
 
     end {

--- a/Watchmen/Public/version.ps1
+++ b/Watchmen/Public/version.ps1
@@ -10,7 +10,7 @@ function Version {
     }
 
     process {
-        $global:watchmen.ThisTest.Version = $Version
+        $script:watchmen.ThisTest.Version = $Version
     }
 
     end {


### PR DESCRIPTION
## Description

Move Watchmen object into `$script` scope instead of `$global` scope.
## Related Issue
#5
## Motivation and Context

Variable is only used internally in the module and should not be exposed.
## How Has This Been Tested?

All tests pass using `.\build.ps1 -Task Test`
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
