### PR TITLE
Fix typo 'descibe'

### DIFF
--- a/Watchmen/Private/ConvertFrom-PlaceholderString.ps1
+++ b/Watchmen/Private/ConvertFrom-PlaceholderString.ps1
@@ -21,7 +21,7 @@
             $string = $string.Replace('#{computername}', $env:COMPUTERNAME)
             $string = $string.Replace('#{module}', $results.module)
             $string = $string.Replace('#{file}', $results.FileName)
-            $string = $string.Replace('#{descibe}', $results.RawResult.Describe)
+            $string = $string.Replace('#{describe}', $results.RawResult.Describe)
             $string = $string.Replace('#{context}', $results.RawResult.Context)
             $string = $string.Replace('#{test}', $results.RawResult.Name)
             $string = $string.Replace('#{result}', $results.Result)

--- a/Watchmen/Private/Notifiers/Invoke-NotifierEmail.ps1
+++ b/Watchmen/Private/Notifiers/Invoke-NotifierEmail.ps1
@@ -32,7 +32,7 @@ Watchmen reported a failure in OVF test:
 
 Module: $($results.Module)
 File: $($results.FileName)
-Descibe:  $($results.RawResult.Describe)
+Describe: $($results.RawResult.Describe)
 Context: $($results.RawResult.Context)
 Test: $($results.RawResult.Name)
 Result: $($results.Result)

--- a/Watchmen/Private/Notifiers/Invoke-NotifierEventLog.ps1
+++ b/Watchmen/Private/Notifiers/Invoke-NotifierEventLog.ps1
@@ -25,7 +25,7 @@ Module: $($results.Module)
 
 File: $($results.FileName)
 
-Descibe:  $($results.RawResult.Describe)
+Describe: $($results.RawResult.Describe)
 
 Context: $($results.RawResult.Context)
 

--- a/Watchmen/Private/Notifiers/Invoke-NotifierSlack.ps1
+++ b/Watchmen/Private/Notifiers/Invoke-NotifierSlack.ps1
@@ -27,7 +27,7 @@ Module: $($results.Module)
 
 File: $($results.FileName)
 
-Descibe:  $($results.RawResult.Describe)
+Describe: $($results.RawResult.Describe)
 
 Context: $($results.RawResult.Context)
 
@@ -44,7 +44,7 @@ Duration: $($results.RawResult.Time.ToString())
             @{title = 'Computer'; value = $env:COMPUTERNAME; short = $true }
             @{title = 'Module'; value = $results.Module; short = $true }
             @{title = 'Test'; value = $results.RawResult.Name; short = $false }
-            @{title = 'Descibe'; value = $results.RawResult.Describe; short = $true }
+            @{title = 'Describe'; value = $results.RawResult.Describe; short = $true }
             @{title = 'Context'; value = $results.RawResult.Context; short = $true }
             @{title = 'File'; value = $results.FileName; short = $false }
             @{title = 'Result'; value = $results.Result; short = $true }

--- a/Watchmen/en-US/Watchmen-help.xml
+++ b/Watchmen/en-US/Watchmen-help.xml
@@ -115,7 +115,7 @@
 <maml:para>computername     - Computer name test was executed on
 module           - OVF module name
 file             - Path to Pester test executed
-descibe          - Name of 'Describe' block in Pester test
+describe         - Name of 'Describe' block in Pester test
 context          - Name of 'Context' block in Pester test
 test             - Name of 'It' block in Pester test
 result           - Result of test. 'Passed' or 'Failed'

--- a/docs/functions/Help-Email.md
+++ b/docs/functions/Help-Email.md
@@ -26,7 +26,7 @@ from the test result:
 computername     - Computer name test was executed on  
 module           - OVF module name  
 file             - Path to Pester test executed  
-descibe          - Name of 'Describe' block in Pester test  
+describe         - Name of 'Describe' block in Pester test  
 context          - Name of 'Context' block in Pester test  
 test             - Name of 'It' block in Pester test  
 result           - Result of test. 'Passed' or 'Failed'  


### PR DESCRIPTION
## Description
This is a breaking change since watchmen files that used the #{descibe}
keyword are no longer going to work as expected.

## Related Issue
#12 

## Motivation and Context
Describe is written 'descibe' throughout the project. This PR fixes the typo but also renders previous watchmen templates that contain the wrong 'descibe' keyword useless.

## How Has This Been Tested?
Ran build.ps1 locally, all tests passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
